### PR TITLE
config: Don't dexpreopt prebuilt apps

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -8,6 +8,9 @@ $(call inherit-product-if-exists, vendor/certification/config.mk)
 ifeq ($(WITH_GMS),true)
 $(call inherit-product, vendor/pixel-framework/config.mk)
 $(call inherit-product, vendor/pixel-style/config/common.mk)
+
+# Don't dexpreopt prebuilts. (For GMS).
+DONT_DEXPREOPT_PREBUILTS := true
 endif
 
 PRODUCT_BRAND ?= EvolutionX


### PR DESCRIPTION
Pre-optimizing prebuilt Gapps is not needed because they are mostly updated via Play Store and device will optimize them on install.

Save some space on /product partition and reduce build time.