### PR TITLE
config: Move adb_root outside userbuild

### DIFF
--- a/bootanimation/prebuilts/prebuilts.mk
+++ b/bootanimation/prebuilts/prebuilts.mk
@@ -17,16 +17,9 @@
 PRODUCT_SOONG_NAMESPACES += \
     vendor/lineage/prebuilts
 
-PRODUCT_COPY_FILES += \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_aokp.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_aokp.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_cm.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_cm.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_ctos.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_ctos.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_cyberpunk.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_cyberpunk.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_du.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_du.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_evo_reveal.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_evo_reveal.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_google.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_google.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_google_monet.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_google_monet.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_pac.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_pac.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_rr.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_rr.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_slim.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_slim.zip \
-    vendor/lineage/bootanimation/prebuilts/bootanimation_valorant.zip:$(TARGET_COPY_OUT_PRODUCT)/media/bootanimation_valorant.zip
+SOURCE_DIR := vendor/lineage/bootanimation/prebuilts
+TARGET_DIR := $(TARGET_COPY_OUT_PRODUCT)/media
+
+BOOTANIMATIONS := $(wildcard $(SOURCE_DIR)/*.zip)
+
+PRODUCT_COPY_FILES := $(foreach file,$(BOOTANIMATIONS),$(file):$(TARGET_DIR)/$(notdir $(file)))

--- a/config/common.mk
+++ b/config/common.mk
@@ -242,10 +242,10 @@ PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
     system/bin/procmem
 endif
 
+ifneq ($(TARGET_BUILD_VARIANT),user)
 # Root
 PRODUCT_PACKAGES += \
     adb_root
-ifneq ($(TARGET_BUILD_VARIANT),user)
 ifeq ($(WITH_SU),true)
 PRODUCT_PACKAGES += \
     su


### PR DESCRIPTION
- Prevent root detection for apps like VNEID