### PR TITLE
build: direchtly update .json in evolution/OTA{-VANILLA} when official

### DIFF
--- a/build/tools/createjson.py
+++ b/build/tools/createjson.py
@@ -4,19 +4,30 @@
 # SPDX-FileCopyrightText: 2025 The Evolution X Project
 # SPDX-License-Identifier: Apache-2.0
 
+import subprocess
 import argparse
 import os
 import hashlib
 import json
 
+def git_fetch(directory):
+    """Run git fetch in a given directory."""
+    try:
+        subprocess.check_call(["git", "fetch"], cwd=directory)
+    except subprocess.CalledProcessError as e:
+        print(f"Git fetch failed in {directory}: {e}")
+
 def generate_json(target_device, product_out, file_name, build_variant, with_gms):
     output = os.path.join(product_out, f"{target_device}.json")
 
-    if os.path.exists(output):
-        os.remove(output)
+    if "Official" in file_name:
+        git_fetch('./evolution/OTA')
+        git_fetch('./evolution/OTA-VANILLA')
+
+        if os.path.exists(output):
+            os.remove(output)
 
     channel = "15_vanilla" if with_gms == "false" else "15"
-
     existing_ota_json = os.path.join(f"./evolution/OTA{'-VANILLA' if with_gms == 'false' else ''}/builds", f"{target_device}.json")
 
     maintainer = ""
@@ -50,6 +61,7 @@ def generate_json(target_device, product_out, file_name, build_variant, with_gms
         download = f"https://cdn.evolution-x.org/{target_device}/{channel}/{file_name}/download"
     else:
         download = f"https://sourceforge.net/projects/your_unoffical_sourceforge_project/files/{target_device}/{channel}/{file_name}/download"
+
     version = file_name.split('-')[4]
     v_max, v_min = version.split('.')[0], version.split('.')[1]
     version = f"{v_max}.{v_min}"
@@ -87,6 +99,10 @@ def generate_json(target_device, product_out, file_name, build_variant, with_gms
 
     with open(output, 'w') as f:
         json.dump(json_data, f, indent=2)
+
+    if "Official" in file_name and os.path.exists(existing_ota_json):
+        with open(existing_ota_json, 'w') as f:
+            json.dump(json_data, f, indent=2)
 
 def get_timestamp_from_buildprop(buildprop_path):
     with open(buildprop_path, 'r') as f:


### PR DESCRIPTION
- For official maintainers building GMS and Vanilla at the same time will this automatically override the .json in evolution/OTA{-VANILLA}
- Since both ota filenames are equal they would override eachother otherwise