### PR TITLE
config: Move adb_root outside userbuild

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -233,9 +233,9 @@ PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
 endif
 
 # Root
+ifneq ($(TARGET_BUILD_VARIANT),user)
 PRODUCT_PACKAGES += \
     adb_root
-ifneq ($(TARGET_BUILD_VARIANT),user)
 ifeq ($(WITH_SU),true)
 PRODUCT_PACKAGES += \
     su


### PR DESCRIPTION
This PR meant to prevent adb root detection in userbuild. adb_root should be only avaliable in userdebug