### PR TITLE
replace PRODUCT_NO_CAMERA with TARGET_BUILD_APERTURE_CAMERA

### DIFF
--- a/config/common_mobile_full.mk
+++ b/config/common_mobile_full.mk
@@ -16,7 +16,7 @@ PRODUCT_PACKAGES += \
     Twelve
 endif
 
-ifneq ($(PRODUCT_NO_CAMERA),true)
+ifneq ($(TARGET_BUILD_APERTURE_CAMERA),true)
 PRODUCT_PACKAGES += \
     Aperture
 endif


### PR DESCRIPTION
We shouldn't rely on checking whether the camera or other components are present instead, we should define a more explicit flag to indicate whether we want to build the Aperture camera or not.