### PR TITLE
evolution: Add support for Pixel OOT kernel building

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -935,7 +935,12 @@ function build_kernel() {
         echo "Skipping kernel build"
         return
     fi
-    local lineage_version="lineage-$(_get_build_var_cached PRODUCT_VERSION_MAJOR).$(_get_build_var_cached PRODUCT_VERSION_MINOR)"
+    local lineage_version=$(echo $(grep -Po '(?<=EVO_VERSION_BASE := )[0-9.]+' ${ANDROID_BUILD_TOP}/vendor/lineage/config/version.mk) | ${ANDROID_BUILD_TOP}/vendor/lineage/build/tools/evo_to_lineage_branch.py)
+
+    if [[ ${lineage_version} == "oops" ]]; then
+        echo "Skipping kernel build: couldn't determine lineage_version"
+        return
+    fi
 
     local target_kernel_device="$(_get_build_var_cached TARGET_KERNEL_DEVICE)"
     local target_kernel_dir="${ANDROID_BUILD_TOP}/$(_get_build_var_cached TARGET_KERNEL_DIR)"

--- a/build/tools/evo_to_lineage_branch.py
+++ b/build/tools/evo_to_lineage_branch.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-FileCopyrightText: 2026 The Evolution X Project
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+def bail():
+    print("oops")
+    exit(1)
+
+# Map Evolution X 11 minor versions to LineageOS minor versions
+def parse_lineage23(v):
+    v = int(v)
+    if v <= 4:
+        return '0'
+    elif v == 5:
+        return '1'
+    else:
+        return '2'
+
+s = input()
+
+# Validate input format (e.g., 11.4, 11.4.2, 11.4.2.1)
+if not re.match(r"[1-9][0-9]\.[0-9]([0-9])?(\.[0-9])?", s): bail()
+
+evo_maj, evo_mnr = s.split('.')[:2]
+
+# Check if major version is supported
+if (int(evo_maj) < 11): bail()
+
+lineage_maj = str(int(evo_maj) + 12)
+lineage_mnr = globals()[f"parse_lineage{lineage_maj}"](evo_mnr)
+cur = f"lineage-{lineage_maj}.{lineage_mnr}"
+
+print(cur)


### PR DESCRIPTION
Gets current evox version by parsing config/version.mk for EVO_VERSION_BASE, then uses a script to convert from evox version to lineage version.

Made while being high, definitely needs improvement.