### PR TITLE
release: Disable media_carousel_arrows flag

### DIFF
--- a/release/aconfig/bp4a/com.android.systemui/media_carousel_arrows_flag_values.textproto
+++ b/release/aconfig/bp4a/com.android.systemui/media_carousel_arrows_flag_values.textproto
@@ -1,0 +1,6 @@
+flag_value {
+  package: "com.android.systemui"
+  name: "media_carousel_arrows"
+  state: DISABLED
+  permission: READ_ONLY
+}


### PR DESCRIPTION
* This was enabled by default, causing the qs media player to display paging arrows when there are multiple sessions, especially in compact mode


| Before | After |
|------ | -------|
| <img width="820" alt="image" src="https://github.com/user-attachments/assets/e5adede5-7afb-4fdd-9b76-8e71c7225693" /> | <img width="820" src="https://github.com/user-attachments/assets/4a5f954b-f41f-4d47-a37f-067793d42d17" /> |
