### PR TITLE
release: Disable enable_multidisplay_trackpad_back_gesture flag

### DIFF
--- a/release/aconfig/bp4a/com.android.window.flags/Android.bp
+++ b/release/aconfig/bp4a/com.android.window.flags/Android.bp
@@ -1,0 +1,21 @@
+// Copyright 2025 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+aconfig_values {
+  name: "aconfig-values-lineage-bp4a-com.android.window.flags-all",
+  package: "com.android.window.flags",
+  srcs: [
+    "*.textproto",
+  ],
+}

--- a/release/aconfig/bp4a/com.android.window.flags/enable_multidisplay_trackpad_back_gesture_flag_values.textproto
+++ b/release/aconfig/bp4a/com.android.window.flags/enable_multidisplay_trackpad_back_gesture_flag_values.textproto
@@ -1,0 +1,6 @@
+flag_value {
+  package: "com.android.window.flags"
+  name: "enable_multidisplay_trackpad_back_gesture"
+  state: DISABLED
+  permission: READ_ONLY
+}


### PR DESCRIPTION
This is incompatible with lineage's long swipe back gesture feature, so disable it until lineage update their implementation.

Hopefully there are more users using long back swipe gestures than users connecting their phone to displays and trackpads.