### PR TITLE
config: Add Mosey nopauth variant selection flag

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -14,8 +14,13 @@ ifeq ($(WITH_GMS),true)
 $(call inherit-product, vendor/google/overlays/ThemeIcons/config.mk)
 $(call inherit-product, vendor/pixel-style/config/common.mk)
 TARGET_INCLUDE_MOSEY ?= false
+TARGET_USES_MOSEY_NOPAUTH ?= false
 ifeq ($(TARGET_INCLUDE_MOSEY),true)
+ifeq ($(TARGET_USES_MOSEY_NOPAUTH),true)
+$(call inherit-product, vendor/gms/mosey_nopauth/mosey-vendor.mk)
+else
 $(call inherit-product, vendor/gms/mosey/mosey-vendor.mk)
+endif
 endif
 
 # Don't dexpreopt prebuilts. (For GMS).


### PR DESCRIPTION
Split Mosey enablement from the binary variant choice.

TARGET_INCLUDE_MOSEY still controls whether Mosey is included at all, while the new TARGET_USES_MOSEY_NOPAUTH flag selects the compatibility packaging from vendor/gms/mosey_nopauth for devices that need the no-PAuth blob.

This keeps the stock Mosey path as the default and lets device trees opt into the compatibility variant only where it is actually required.